### PR TITLE
Use Deno.serve instead of std/http

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,14 @@
-import { serve } from "https://deno.land/std@0.176.0/http/server.ts";
+const port = parseInt(Deno.env.get("PORT") ?? "8000");
 
-let port = parseInt(Deno.env.get("PORT") ?? "8000");
-const s = serve({ port });
-
-console.log(`http://localhost:${port}/`);
-
-for await (const req of s) {
-	req.respond({ body: "Choo Choo! Welcome to your Deno app\n" });
-}
+Deno.serve(
+  {
+    port: port,
+    onListen:
+      (({ hostname, port }) =>
+        console.log(`Listening on http://${hostname}:${port}/`)),
+  },
+  (req) =>
+    new Response(
+      `Choo Choo! Welcome to your Deno app on address: ${req.url}\n`,
+    ),
+);


### PR DESCRIPTION
Deno provides a much simpler API with no need for any imports and dependencies nowadays, so i think this template should move to it.